### PR TITLE
Update organization name and fix bitnami repo link

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,12 +35,12 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.12.10
-          - v1.13.12
-          - v1.14.10
-          - v1.15.11
-          - v1.16.8
-          - v1.17.4
+          - v1.22.17
+          - v1.23.17
+          - v1.24.13
+          - v1.25.8
+          - v1.26.3
+          - v1.27.0
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # helm-charts
 
-## mundialis helm repo
+## actinia-org helm repo
 
-    helm repo add mundialis https://mundialis.github.io/helm-charts/
+    helm repo add actinia-org https://actinia-org.github.io/helm-charts/
     helm repo update
-    helm search repo mundialis -l
+    helm search repo actinia-org -l
 
 ## commit changes to chart
 GitHub Actions for linting:
@@ -19,18 +19,17 @@ a release is made for each chart in case the chart version was changed.
 ## examples
 
 ### prerequisites
-    helm repo add mundialis https://mundialis.github.io/helm-charts/
+    helm repo add actinia-org https://actinia-org.github.io/helm-charts/
     helm repo update
 
 ### install actinia with default values
-    helm upgrade --install actinia mundialis/actinia
+    helm upgrade --install actinia actinia-org/actinia
 
 ### install actinia with persistence
-    helm upgrade --install actinia mundialis/actinia --set "persistence.enabled=true" --set "redis.master.persistence.enabled=true"
+    helm upgrade --install actinia actinia-org/actinia --set "persistence.enabled=true" --set "redis.master.persistence.enabled=true"
 
 ### install actinia with ingress enabled
-    helm upgrade --install actinia mundialis/actinia --set "ingress.enabled=true"
-
+    helm upgrade --install actinia actinia-org/actinia --set "ingress.enabled=true"
 
 # Local testing
 
@@ -48,4 +47,4 @@ Make you local changes and then run e.g.
     helm package -u charts/*
     # or only build a single chart
     helm package -u charts/openeo-grassgis-driver/
-    helm repo index --url https://mundialis.github.io/helm-charts/ .
+    helm repo index --url https://actinia-org.github.io/helm-charts/ .

--- a/charts/actinia/Chart.yaml
+++ b/charts/actinia/Chart.yaml
@@ -23,4 +23,6 @@ appVersion: 2.2.2
 dependencies:
 - name: redis
   version: "12"
-  repository: "https://charts.bitnami.com/bitnami"
+  # repository: "https://charts.bitnami.com/bitnami"
+  # old versions of redis are not part of the bitnami repo anymore, see https://github.com/bitnami/charts/issues/10663#issuecomment-1149908401
+  repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"

--- a/charts/actinia/Chart.yaml
+++ b/charts/actinia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.3
+version: 2.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -22,7 +22,5 @@ appVersion: 2.2.2
 
 dependencies:
 - name: redis
-  version: "12"
-  # repository: "https://charts.bitnami.com/bitnami"
-  # old versions of redis are not part of the bitnami repo anymore, see https://github.com/bitnami/charts/issues/10663#issuecomment-1149908401
-  repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
+  version: "17.9.5"
+  repository: "https://charts.bitnami.com/bitnami"

--- a/charts/actinia/helmdocs.md
+++ b/charts/actinia/helmdocs.md
@@ -54,7 +54,7 @@ Current chart version is `2.2.3`
 | persistence.userdata.storageClassName | string | `"default"` |  |
 | persistence.userdata.storageSize | string | `"10Gi"` |  |
 | podSecurityContext | object | `{}` |  |
-| redis.cluster.enabled | bool | `false` |  |
+| redis.architecture | string | `standalone` |  |
 | redis.master.persistence.enabled | bool | `false` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/actinia/helmdocs.md
+++ b/charts/actinia/helmdocs.md
@@ -25,7 +25,7 @@ Current chart version is `2.2.3`
 | config.redis | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"mundialis/actinia"` |  |
+| image.repository | string | `"actinia-org/actinia"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/actinia/helmdocs.md
+++ b/charts/actinia/helmdocs.md
@@ -2,7 +2,7 @@ actinia
 =======
 A Helm chart for actinia
 
-Current chart version is `2.2.3`
+Current chart version is `2.2.4`
 
 
 
@@ -10,7 +10,7 @@ Current chart version is `2.2.3`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | redis | 12 |
+| https://charts.bitnami.com/bitnami | redis | 17.9.5 |
 
 ## Chart Values
 
@@ -54,7 +54,7 @@ Current chart version is `2.2.3`
 | persistence.userdata.storageClassName | string | `"default"` |  |
 | persistence.userdata.storageSize | string | `"10Gi"` |  |
 | podSecurityContext | object | `{}` |  |
-| redis.architecture | string | `standalone` |  |
+| redis.architecture | string | `"standalone"` |  |
 | redis.master.persistence.enabled | bool | `false` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/actinia/values.yaml
+++ b/charts/actinia/values.yaml
@@ -118,11 +118,11 @@ config:
     #port: 6379
     #password: password
 
-# https://github.com/bitnami/charts/tree/master/bitnami/redis
+# https://github.com/bitnami/charts/tree/main/bitnami/redis
 redis:
-  #password: password
-  cluster:
-    enabled: false
+  # auth:
+  #   password: password
+  architecture: standalone
   master:
     persistence:
       enabled: false

--- a/charts/actinia/values.yaml
+++ b/charts/actinia/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: mundialis/actinia
+  repository: actinia-org/actinia
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/openeo-grassgis-driver/Chart.yaml
+++ b/charts/openeo-grassgis-driver/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.31
+version: 0.2.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/openeo-grassgis-driver/helmdocs.md
+++ b/charts/openeo-grassgis-driver/helmdocs.md
@@ -17,7 +17,7 @@ Current chart version is `0.2.31`
 | config.actinia_version | string | `"v3"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"mundialis/openeo-grassgis-driver"` |  |
+| image.repository | string | `"actinia-org/openeo-grassgis-driver"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/openeo-grassgis-driver/helmdocs.md
+++ b/charts/openeo-grassgis-driver/helmdocs.md
@@ -2,7 +2,7 @@ openeo-grassgis-driver
 ======================
 A Helm chart for openeo-grassgis-driver
 
-Current chart version is `0.2.31`
+Current chart version is `0.2.32`
 
 
 

--- a/charts/openeo-grassgis-driver/values.yaml
+++ b/charts/openeo-grassgis-driver/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: mundialis/openeo-grassgis-driver
+  repository: actinia-org/openeo-grassgis-driver
   pullPolicy: IfNotPresent
 
 config:

--- a/charts/openeo-web-editor/Chart.yaml
+++ b/charts/openeo-web-editor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openeo-web-editor/helmdocs.md
+++ b/charts/openeo-web-editor/helmdocs.md
@@ -2,7 +2,7 @@ openeo-web-editor
 =================
 A Helm chart for openeo-web-editor
 
-Current chart version is `0.1.2`
+Current chart version is `0.1.3`
 
 
 

--- a/charts/openeo-web-editor/helmdocs.md
+++ b/charts/openeo-web-editor/helmdocs.md
@@ -19,7 +19,7 @@ Current chart version is `0.1.2`
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"mundialis/openeo-web-editor"` |  |
+| image.repository | string | `"actinia-org/openeo-web-editor"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/openeo-web-editor/values.yaml
+++ b/charts/openeo-web-editor/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: mundialis/openeo-web-editor
+  repository: actinia-org/openeo-web-editor
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   # tag: "latest"


### PR DESCRIPTION
- updates README and charts for the new organization name, especially the gh-pages links (i.e. https://mundialis.github.io/helm-charts/) were not working anymore
- uses a legacy bitnami repo because the current one does not support versions older than v16 (see #53)
- in the future the redis version should probably be updated, the newest version is `17.9.5`
   - this seems to be a bigger change, as this are multiple major versions. Link to the upgrade notes: https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1300 

@metzm @mmacata Please review

Should I update the chart versions?